### PR TITLE
fix: add check for CI in hooks

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,8 @@
 #!/bin/sh
+
+# skip hook when in CI
+[ -n "$CI" ] && exit 0
+
 . "$(dirname "$0")/_/husky.sh"
 
 yarn commitlint --edit ${1}

--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -1,4 +1,8 @@
 #!/bin/sh
+
+# skip hook when in CI
+[ -n "$CI" ] && exit 0
+
 . "$(dirname "$0")/_/husky.sh"
 
 yarn install

--- a/.husky/post-commit
+++ b/.husky/post-commit
@@ -1,4 +1,8 @@
 #!/bin/sh
+
+# skip hook when in CI
+[ -n "$CI" ] && exit 0
+
 . "$(dirname "$0")/_/husky.sh"
 
 git status

--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,4 +1,8 @@
 #!/bin/sh
+
+# skip hook when in CI
+[ -n "$CI" ] && exit 0
+
 . "$(dirname "$0")/_/husky.sh"
 
 yarn install

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,8 @@
 #!/bin/sh
+
+# skip hook when in CI
+[ -n "$CI" ] && exit 0
+
 . "$(dirname "$0")/_/husky.sh"
 
 yarn pretty-quick --staged && yarn lint && yarn test

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,8 @@
 #!/bin/sh
+
+# skip hook when in CI
+[ -n "$CI" ] && exit 0
+
 . "$(dirname "$0")/_/husky.sh"
 
 yarn lint && yarn build


### PR DESCRIPTION
This PR adds check for the `CI` env variable in the hooks and skips them if it is set.
Usually in continuous integration environnement we do not want to run the hooks, we have tests that run automatically.

closes #8 